### PR TITLE
typo?

### DIFF
--- a/custom-pipeline-pod-templates.md
+++ b/custom-pipeline-pod-templates.md
@@ -31,7 +31,7 @@ spec:
 ```
       agent {
         kubernetes {
-          label 'nodejs-app-pod'
+          label 'nodejs-app-pod-2'
           yamlFile 'nodejs-pod.yaml'
         }
       }


### PR DESCRIPTION
Added missing '-2' to the end of the agent kubernetes label description